### PR TITLE
fix build on OsX.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,13 +25,6 @@ endif(CMAKE_C_COMPILER_ID STREQUAL Clang OR CMAKE_C_COMPILER_ID STREQUAL AppleCl
 find_package(OpenSSL 1.0.1 REQUIRED COMPONENTS Crypto)
 find_program(A2X a2x)
 
-# fix linking to OpenSSL on OsX.
-# The system OpenSSL libraries in /usr/lib/ don't have any header files
-# installed. We'll use a OpenSSL library installed with homebrew.
-if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
-set(OPENSSL_CRYPTO_LIBRARY "-L/usr/local/opt/openssl/lib -lcrypto")
-endif("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
-
 configure_file(config.h.in config.h)
 
 add_library(aes_siv SHARED aes_siv.c)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,20 +25,31 @@ endif(CMAKE_C_COMPILER_ID STREQUAL Clang OR CMAKE_C_COMPILER_ID STREQUAL AppleCl
 find_package(OpenSSL 1.0.1 REQUIRED COMPONENTS Crypto)
 find_program(A2X a2x)
 
+# fix linking to OpenSSL on OsX.
+# The system OpenSSL libraries in /usr/lib/ don't have any header files
+# installed. We'll use a OpenSSL library installed with homebrew.
+if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
+set(OPENSSL_CRYPTO_LIBRARY "-L/usr/local/opt/openssl/lib -lcrypto")
+endif("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
+
 configure_file(config.h.in config.h)
 
 add_library(aes_siv SHARED aes_siv.c)
+target_compile_options(aes_siv PUBLIC -I${OPENSSL_INCLUDE_DIR})
 target_link_libraries(aes_siv ${OPENSSL_CRYPTO_LIBRARY})
 set_target_properties(aes_siv PROPERTIES VERSION "1.0.0" SOVERSION 1)
 
 add_library(aes_siv_static STATIC aes_siv.c)
+target_compile_options(aes_siv_static PUBLIC -I${OPENSSL_INCLUDE_DIR})
 target_link_libraries(aes_siv_static ${OPENSSL_CRYPTO_LIBRARY})
 set_target_properties(aes_siv_static PROPERTIES OUTPUT_NAME aes_siv)
 
 add_executable(demo demo.c)
+target_compile_options(demo PUBLIC -I${OPENSSL_INCLUDE_DIR})
 target_link_libraries(demo ${OPENSSL_CRYPTO_LIBRARY} aes_siv_static)
 
 add_executable(runtests aes_siv_test.c tests.c)
+target_compile_options(runtests PUBLIC -I${OPENSSL_INCLUDE_DIR})
 target_link_libraries(runtests ${OPENSSL_CRYPTO_LIBRARY})
 if(ENABLE_COVERAGE)
   target_compile_options(runtests PRIVATE "--coverage")

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ environment and the command line tools, then use the Homebrew package
 manager https://brew.sh/ to install cmake and OpenSSL:
 ```
     brew install cmake openssl
-    OPENSSL_ROOT_DIR=/usr/local/opt/openssl cmake .
+    cmake -DCMAKE_PREFIX_PATH=/usr/local/opt/openssl .
     make
     make test
     sudo make install

--- a/README.md
+++ b/README.md
@@ -76,6 +76,17 @@ To build and install on POSIX-like platforms:
     sudo make install
 ```
 
+If you want to build on a OsX machine, install the Xcode development
+environment and the command line tools, then use the Homebrew package
+manager https://brew.sh/ to install cmake and OpenSSL:
+```
+    brew install cmake openssl
+    OPENSSL_ROOT_DIR=/usr/local/opt/openssl cmake .
+    make
+    make test
+    sudo make install
+```
+
 ## Usage
 
 See the manual pages for API documentation, and the test vectors

--- a/demo.c
+++ b/demo.c
@@ -9,9 +9,6 @@
 #include "aes_siv.h"
 #include <assert.h>
 #include <errno.h>
-#ifdef __linux__
-#include <malloc.h>
-#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/demo.c
+++ b/demo.c
@@ -9,7 +9,9 @@
 #include "aes_siv.h"
 #include <assert.h>
 #include <errno.h>
+#ifdef __linux__
 #include <malloc.h>
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
these are some changes to build the library on OsX. While OsX ships with OpenSSL library files, they don't provide the corresponding header files any more. Using "homebrew" a OpenSSL library is installed into /usr/local/opt/openssl and we needed some cmake changes to link against that library.
Also the malloc.h header file doesn't exist on OsX, and malloc() is provided by the stdlib.h header file.