### PR TITLE
Adds option to disable building docs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,9 @@ set(CMAKE_C_FLAGS_MINSIZEREL "-Wall -Wextra -Wstrict-prototypes -Wconversion -Os
 endif(CMAKE_C_COMPILER_ID STREQUAL Clang OR CMAKE_C_COMPILER_ID STREQUAL AppleClang)
 
 find_package(OpenSSL 1.0.1 REQUIRED COMPONENTS Crypto)
-find_program(A2X a2x)
+if(NOT DISABLE_DOCS)
+  find_program(A2X a2x)
+endif(NOT DISABLE_DOCS)
 
 configure_file(config.h.in config.h)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
It's useful to have a packaging option to determine whether to require
asciidoc and build the manpages.  But with the condition being solely
based on the opportunistic discovery of asciidoc, simply removing the
dependency gives non-reproducible results.  This adds an option to
explicitly disable the documentation, by pretending that 'a2x' doesn't
exist.

TESTED:
With asciidoc present, manpages are still built by default, but not
built if "-DDISABLE_DOCS=1 is included on the cmake command line.