### PR TITLE
Fixes test crash with OpenSSL < 1.0.2b.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ bench
 libaes_siv.a
 libaes_siv.so
 libaes_siv.so.*
+libaes_siv.dylib
+libaes_siv.*.dylib
 CMakeCache.txt
 CMakeFiles/
 *.cmake

--- a/aes_siv.c
+++ b/aes_siv.c
@@ -239,8 +239,13 @@ void AES_SIV_CTX_cleanup(AES_SIV_CTX *ctx) {
 void AES_SIV_CTX_free(AES_SIV_CTX *ctx) {
         if (ctx) {
                 EVP_CIPHER_CTX_free(ctx->cipher_ctx);
-                CMAC_CTX_free(ctx->cmac_ctx_init);
-                CMAC_CTX_free(ctx->cmac_ctx);
+                /* Prior to OpenSSL 1.0.2b, CMAC_CTX_free() crashes on NULL */
+                if (LIKELY(ctx->cmac_ctx_init != NULL)) {
+                        CMAC_CTX_free(ctx->cmac_ctx_init);
+                }
+                if (LIKELY(ctx->cmac_ctx != NULL)) {
+                        CMAC_CTX_free(ctx->cmac_ctx);
+                }
 		OPENSSL_cleanse(&ctx->d, sizeof ctx->d);
                 free(ctx);
         }

--- a/tests.c
+++ b/tests.c
@@ -77,7 +77,7 @@ static void test_malloc_failure(void) {
 #endif
         assert(ret == 1);
 
-        printf("Test allocation failure:\n" );
+        printf("Test allocation failure cases:\n" );
 
         do {
                 fail_allocation_counter = i++;


### PR DESCRIPTION
This PR also includes two other minor commits, but the important one is aa4fd8a.
