### PR TITLE
support CentOS 7 cmake 2.8.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
-cmake_minimum_required (VERSION 3.1)
-project(libaes_siv LANGUAGES C)
+cmake_minimum_required (VERSION 2.8.12)
+project(libaes_siv)
+enable_language(C)
 set(CMAKE_C_STANDARD 99)
 if("${CMAKE_BUILD_TYPE}" STREQUAL "")
 set(CMAKE_BUILD_TYPE Release)

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Build dependencies:
   features are required, however `<stdint.h>` must be available and
   must define `uint64_t`. `char` must be 8 bits and arithmetic must be
   two's complement.
-* [CMake](https://cmake.org) >= 3.1
+* [CMake](https://cmake.org) >= 2.8.12
 * [OpenSSL](https://openssl.org) >=1.0.1 (libcrypto only). A recent
   release from the 1.0.2 branch or later is strongly recommended since
   1.0.1 was EOL'ed at the end of 2016. Furthermore, OpenSSL versions prior


### PR DESCRIPTION
CentOS 7 has an older version of cmake, but it has all the other deps.  The change needed to support it is pretty simple.

Tested on:
* CentOS 7, cmake 2.8.12.2
* Ubuntu 18.04, cmake 3.10.2
* Fedora 30, cmake 3.14.5