### PR TITLE
use OPENSSL_malloc/free

### DIFF
--- a/aes_siv.c
+++ b/aes_siv.c
@@ -247,12 +247,12 @@ void AES_SIV_CTX_free(AES_SIV_CTX *ctx) {
                         CMAC_CTX_free(ctx->cmac_ctx);
                 }
 		OPENSSL_cleanse(&ctx->d, sizeof ctx->d);
-                free(ctx);
+                OPENSSL_free(ctx);
         }
 }
 
 AES_SIV_CTX *AES_SIV_CTX_new(void) {
-        AES_SIV_CTX *ctx = malloc(sizeof(struct AES_SIV_CTX_st));
+        AES_SIV_CTX *ctx = OPENSSL_malloc(sizeof(struct AES_SIV_CTX_st));
         if (UNLIKELY(ctx == NULL)) {
                 return NULL;
         }


### PR DESCRIPTION
these were erroneously changed to the standard malloc/free in
911655411da6333cf75f23ccbc47cd4941c11dd3 in contradiction to
AES_SIV_CTX_new.adoc